### PR TITLE
add loader for yaml

### DIFF
--- a/kiwi/kiwi/core/common.py
+++ b/kiwi/kiwi/core/common.py
@@ -34,7 +34,7 @@ class YamlConf(object):
     def __new__(cls, path):
         try:
             _file = open(path,"r")
-            result = yaml.load(_file)
+            result = yaml.load(_file, loader=yaml.FullLoader)
         except IOError:
             raise FileError(
                 "Loading yaml file '{0}' failed, read file failed".format(path))


### PR DESCRIPTION
5.1弃用了load原本的用法
在yaml.load(list, loader=yaml.FullLoader) 加上 load=yaml.FullLoader。